### PR TITLE
引用コピー時にScroll To Text FragmentをURLに使用

### DIFF
--- a/chrome-extension/background/background.js
+++ b/chrome-extension/background/background.js
@@ -34,6 +34,8 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 		});
 	}).then(selectionText => {
 		const url = (() => {
+			if (!selectionText) return tab.url;
+
 			const _url = new URL(tab.url);
 
 			if (_url.hash && !_url.hash.startsWith('#:~:text=')) return tab.url;

--- a/chrome-extension/background/background.js
+++ b/chrome-extension/background/background.js
@@ -36,7 +36,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 		const url = (() => {
 			const _url = new URL(tab.url);
 
-			if (_url.hash) return tab.url;
+			if (_url.hash && !_url.hash.startsWith('#:~:text=')) return tab.url;
 
 			const [ firstLineSelectionText ] = selectionText.trim().split(/\n+/);
 			_url.hash = `:~:text=${encodeURIComponent(firstLineSelectionText)}`;

--- a/chrome-extension/background/background.js
+++ b/chrome-extension/background/background.js
@@ -33,8 +33,17 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 			resolve(info.selectionText);
 		});
 	}).then(selectionText => {
+		const url = (() => {
+			const _url = new URL(tab.url);
+
+			if (_url.hash) return tab.url;
+
+			const [ firstLineSelectionText ] = selectionText.trim().split(/\n+/);
+			_url.hash = `:~:text=${encodeURIComponent(firstLineSelectionText)}`;
+			return _url.toString();
+		})();
 		const data = {
-			url: tab.url,
+			url,
 			title: tab.title,
 		};
 		// Firefox用


### PR DESCRIPTION
Chrome 80 から使えるURL の  `#:~:text=テキスト` でスクロール＆ハイライトする機能

## 参考
- [Scroll To Text Fragment と :~:text | blog.jxck.io](https://blog.jxck.io/entries/2019-10-16/scroll-to-text-fragment.html)

## Todo
- [ ] 複数行対応
- [ ] 有効/無効の設定追加