### PR TITLE
feat: migrate to manifest v3

### DIFF
--- a/chrome-extension/background/background.html
+++ b/chrome-extension/background/background.html
@@ -1,1 +1,0 @@
-<script type="module" src="./background.js"></script>

--- a/chrome-extension/background/background.js
+++ b/chrome-extension/background/background.js
@@ -1,12 +1,35 @@
+import i18n from '../i18n.js';
+/*
 import {
 	createContextMenus,
 	findTemplateFrom,
  } from '../ContextMenuUtil.js';
+*/
+
+const contextMenuId = 'popup';
+const createContextMenus = () => {
+	chrome.contextMenus.removeAll(() => {
+		chrome.contextMenus.create({
+			title: i18n.getMessage('extension_name'),
+			id: contextMenuId,
+			contexts: [
+				'page',
+			],
+		});
+
+	});
+};
 
 chrome.runtime.onInstalled.addListener(createContextMenus);
 chrome.runtime.onStartup.addListener(createContextMenus);
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+chrome.contextMenus.onClicked.addListener((info) => {
+	if (info.menuItemId === contextMenuId) {
+		chrome.action.openPopup();
+	}
+
+	// TODO: manifest v3 (service workerに対応できたら復活させる)
+	/*
 	const template = findTemplateFrom(info.menuItemId);
 	if (!template) return;
 
@@ -53,4 +76,5 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 		container.remove();
 	});
+	*/
 });

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "__MSG_extension_name__",
 	"version": "1.1.1",
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"minimum_chrome_version": "61",
 	"default_locale": "en",
 	"homepage_url": "https://chrome.google.com/webstore/detail/nnnflohcklplblcndpidebcbkdfbjmdm",
@@ -16,11 +16,11 @@
 		"clipboardWrite"
 	],
 	"background": {
-		"persistent": false,
-		"page": "background/background.html"
+		"service_worker": "background/background.js",
+		"type": "module"
 	},
 	"options_page": "options/options.html",
-	"browser_action": {
+	"action": {
 		"default_icon": "icon/icon.png",
 		"default_title": "__MSG_extension_name__",
 		"default_popup": "browser-action/popup.html"


### PR DESCRIPTION
コンテキストメニューからの共有も含めてv3対応するのは時間が掛かりそうなので、とりあえずpopupページで動かせる範囲だけ移行

### ~~TODO(削除すべきもの)~~
- [ ] `document`
- [ ] `extends HTMLElement`
- [ ] `window.customElements.define`
- [ ] `localStorage` (popupページでは使えるので、後回しでOK。設定移行のためにも。)

### 参考
- [chrome.action.openPopup()](https://developer.chrome.com/docs/extensions/reference/api/action?hl=ja#method-openPopup)